### PR TITLE
[QA] ANNO-187 Added CustomEvent polyfill

### DIFF
--- a/src/Compatibility.js
+++ b/src/Compatibility.js
@@ -24,6 +24,8 @@ define(function() {
      * When we are running a browser without a console (IE<=9), there will
      * be no console object and things will break, so make one!
      *
+     * IE doesn't have a CustomEvent event constructor, so make one!
+     *
      * @constructor
      *
      * @name Compatibility
@@ -41,6 +43,21 @@ define(function() {
                 warn: function() {},
                 error: function() {}
             };
+        }
+
+        if (typeof configuration.window.CustomEvent === 'undefined' || typeof configuration.window.CustomEvent === 'object') {
+            (function () {
+                function CustomEvent ( event, params ) {
+                    params = params || { bubbles: false, cancelable: false, detail: undefined };
+                    var evt = document.createEvent( 'CustomEvent' );
+                    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+                    return evt;
+                }
+
+                CustomEvent.prototype = configuration.window.Event.prototype;
+
+                configuration.window.CustomEvent = CustomEvent;
+            })();
         }
     };
 

--- a/test/CompatibilitySpec.js
+++ b/test/CompatibilitySpec.js
@@ -22,7 +22,8 @@ define(function(require) {
     describe('Compatibility', function() {
         it('should create a console if it is undefined', function () {
             var tempWindow = {
-                console: undefined
+                console: undefined,
+                CustomEvent: function(){}
             };
             var testConfiguration = {
                 window: tempWindow
@@ -38,7 +39,8 @@ define(function(require) {
 
         it('should test all of the generated console functions', function() {
             var tempWindow = {
-                console: undefined
+                console: undefined,
+                CustomEvent: function(){}
             };
 
             var testConfiguration = {
@@ -63,6 +65,65 @@ define(function(require) {
             var testCompatibility = new Compatibility.constructor(testConfiguration);
             expect(testCompatibility).toBeDefined();
             expect(window.console).toBe(expectedConsole);
+        });
+
+        it('should polyfill the CustomEvent constructor if it is an object', function() {
+            var tempWindow = {
+                CustomEvent: {},
+                Event: {
+                    prototype: {}
+                }
+            };
+
+            var testConfiguration = {
+                window: tempWindow
+            };
+
+            var testCompatibility = new Compatibility.constructor(testConfiguration);
+            expect(testCompatibility).toBeDefined();
+            expect(tempWindow.CustomEvent).toEqual(jasmine.any(Function));
+            expect(tempWindow.CustomEvent).not.toEqual(jasmine.any(Object));
+        });
+
+        it('should polyfill the CustomEvent constructor if it is undefined', function() {
+            var tempWindow = {
+                CustomEvent: undefined,
+                Event: {
+                    prototype: {}
+                }
+            };
+
+            var testConfiguration = {
+                window: tempWindow
+            };
+
+            var testCompatibility = new Compatibility.constructor(testConfiguration);
+            expect(testCompatibility).toBeDefined();
+            expect(tempWindow.CustomEvent).toEqual(jasmine.any(Function));
+            expect(tempWindow.CustomEvent).not.toEqual(jasmine.any(Object));
+        });
+
+        it('should not polyfill the CustomEvent constructor if it is a function', function() {
+            var mockObject = {
+                test: 'valid'
+            };
+
+            var tempWindow = {
+                CustomEvent: function() { return mockObject; },
+                Event: {
+                    prototype: {}
+                }
+            };
+
+            var testConfiguration = {
+                window: tempWindow
+            };
+
+            var result = testConfiguration.window.CustomEvent();
+
+            var testCompatibility = new Compatibility.constructor(testConfiguration);
+            expect(testCompatibility).toBeDefined();
+            expect(result).toEqual(mockObject);
         });
     });
 });


### PR DESCRIPTION
**ULTIMATE PROBLEM:**
DOM4 Has added support for CustomEvent: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent

But it is not supported in IE. 

**HOW IT WAS FIXED:**
Added a polyfill constructor to support CustomEvent in IE.

**TESTING SUGGESTIONS:**
This was added for: https://github.com/WebFilings/wf-js-annotations/pull/250
You can follow the testing suggestions outline there.

---

**FYA:**  @timmccall-wf @trentgrover-wf 
**FYI:** @tonyhelvey-wf @ericdebusschere-wf 

---
