### PR TITLE
Include hasTouch when calculating tablet, mobile detection

### DIFF
--- a/src/DOMUtil.js
+++ b/src/DOMUtil.js
@@ -281,11 +281,12 @@ define(function() {
         },
 
         width: function(element) {
-            var width = element.offsetWidth;
+            var boundingRect = element.getBoundingClientRect();
+            var width = boundingRect.width;
 
             if (width === 0 && element.style.display === 'none') {
                 this.makeMeasureReady(element, function(element) {
-                    width = element.offsetWidth;
+                    width = element.getBoundingClientRect().width;
                 });
             }
             else if (width === 0 && element.style.display === '') {
@@ -294,7 +295,7 @@ define(function() {
                     parent = parent.parentElement;
                 }
                 if (parent) {
-                    width = parent.offsetWidth;
+                    width = parent.getBoundingClientRect().width;
                 }
             }
 

--- a/src/DeviceInfo.js
+++ b/src/DeviceInfo.js
@@ -23,9 +23,9 @@ define(function(require) {
      *
      * @exports DeviceInfo
      */
-    var DeviceInfo = function(window) {
+    var DeviceInfo = function(window, bowserOverride) {
 
-        var bowser = require('bowser');
+        var bowser = bowserOverride || require('bowser');
 
         /**
          * The width of the screen in pixels

--- a/test/DeviceInfoSpec.js
+++ b/test/DeviceInfoSpec.js
@@ -118,7 +118,10 @@ define(function(require) {
         describe('EVENTS.WINDOW_RESIZE', function() {
             it('should return "orientationchange" if window defines ontouchstart', function() {
                 fakeWindow.ontouchstart = function() {};
-                var deviceInfo = new DeviceInfo.constructor(fakeWindow);
+                var fakeBowser = {
+                    mobile: true
+                };
+                var deviceInfo = new DeviceInfo.constructor(fakeWindow, fakeBowser);
                 expect(deviceInfo.EVENTS.WINDOW_RESIZE).toBe('orientationchange');
             });
             it('should return "resize" if window does not define ontouchstart', function() {


### PR DESCRIPTION
# Problem

When using bowser it reports IE on Windows Tablet PC version or Media Center PC version as tablets since it has the word tablet in their user agent strings.
# Solution

Combine that check with whether the device has a touch screen.
# Testing
- Tests added
- Tests should all pass
