### PR TITLE
HY-1849 - Detect Touch-enabled IE on Surface

### DIFF
--- a/src/DeviceInfo.js
+++ b/src/DeviceInfo.js
@@ -61,7 +61,9 @@ define(function(require) {
          * The device has touch events
          * @type {boolean}
          */
-        this.hasTouch = ('ontouchstart' in window);
+        // UserAgents with 'Touch' is IE on Microsoft Surfaces
+        this.hasTouch = ('ontouchstart' in window) ||
+            window.navigator.userAgent.toLowerCase().indexOf('touch') !== -1;
 
         /**
          * The device is a mobile device

--- a/test/DeviceInfoSpec.js
+++ b/test/DeviceInfoSpec.js
@@ -34,6 +34,9 @@ define(function(require) {
                 screen: {
                     width: 0,
                     height: 0
+                },
+                navigator: {
+                    userAgent: 'nuffin'
                 }
             };
         });
@@ -95,6 +98,11 @@ define(function(require) {
             it('should return false if window does not define ontouchstart', function() {
                 var deviceInfo = new DeviceInfo.constructor(fakeWindow);
                 expect(deviceInfo.hasTouch).toBe(false);
+            });
+            it('should return true for IE on Microsoft Surfaces', function() {
+                fakeWindow.navigator.userAgent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)';
+                var deviceInfo = new DeviceInfo.constructor(fakeWindow);
+                expect(deviceInfo.hasTouch).toBe(true);
             });
         });
 


### PR DESCRIPTION
# Problem
Binders was difficult to use with IE on a surface, because you could not swipe.  The device was not detected as a touch-enabled device.

# Solution
It seems that the window object does not have ontouchstart on it for some reason, but it does have ‘Touch’ in the user agent.  Look for that if there is no ontouchstart.

# How to Test   
1. CI succeeds.
1. View a binder on a Surface.  Attempt to use swipes to change pages, or do anything.  Nothing happens.
1. Link this common branch into books.  Attempt the same swipes, and notice how those actions work as they do on other mobile devices.