### PR TITLE
HV-547 Add namespace function

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 WebFilings, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(function() {
+    'use strict';
+
+    /* jshint global window */
+
+    /**
+     * Sets the object on window under a namespaced dot separated path
+     * @param  {String} path dot separated path of where to place the object
+     *         The last element is the name of the object
+     *         Example: ns('path1.path2.ObjectName', obj);
+     *         Example: ns('MyObject', obj); // places it directly on window
+     * @param  {Object} object the object to set
+     * @return {Object} the original object parameter
+     */
+    function ns(path, object) {
+        var pieces = (path || '').split('.');
+        var addTo = window;
+        if (pieces.length > 0) {
+            name = pieces.pop();
+            for (var i = 0; i < pieces.length; i++) {
+                var piece = pieces[i];
+                addTo[piece] = addTo[piece] || Object.create(null);
+                addTo = addTo[piece];
+            }
+            addTo[name] = object;
+        }
+        return object;
+    }
+    ns('wk.ns', ns);
+    return ns;
+});

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -17,7 +17,7 @@
 define(function() {
     'use strict';
 
-    /* jshint global window */
+    /* global window */
 
     /**
      * Sets the object on window under a namespaced dot separated path
@@ -32,7 +32,7 @@ define(function() {
         var pieces = (path || '').split('.');
         var addTo = window;
         if (pieces.length > 0) {
-            name = pieces.pop();
+            var name = pieces.pop();
             for (var i = 0; i < pieces.length; i++) {
                 var piece = pieces[i];
                 addTo[piece] = addTo[piece] || Object.create(null);

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -42,6 +42,6 @@ define(function() {
         }
         return object;
     }
-    ns('wk.ns', ns);
+
     return ns;
 });

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -26,10 +26,16 @@ define(function() {
      *         Example: ns('path1.path2.ObjectName', obj);
      *         Example: ns('MyObject', obj); // places it directly on window
      * @param  {Object} object the object to set
-     * @return {Object} the original object parameter
+     * @return {Object} the original object parameter or undefined if it was
+     *                  unable to set it on window (empty path for example)
      */
-    function ns(path, object) {
-        var pieces = (path || '').split('.');
+    function namespace(path, object) {
+        // replace everything but alphanumeric, $ _ and .
+        // . will be split out ensuring valid js identifiers
+        var pieces = (path || '').replace(/[^a-z0-9$_.]/gi,'').split('.');
+        if (pieces.length === 0 || pieces[0] === '') {
+            return undefined;
+        }
         var addTo = window;
         if (pieces.length > 0) {
             var name = pieces.pop();
@@ -43,5 +49,5 @@ define(function() {
         return object;
     }
 
-    return ns;
+    return namespace;
 });

--- a/test/namespaceSpec.js
+++ b/test/namespaceSpec.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 WebFilings, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(function(require) {
+    'use strict';
+
+    /* global window */
+
+    var ns = require('wf-js-common/namespace');
+    var obj = {
+        test: 'my object'
+    };
+
+    describe('namespace', function() {
+
+        it('should put obects directly on window when the path is 1 element', function() {
+            ns('MyObject', obj);
+            expect(window.MyObject).toBe(obj);
+        });
+
+        it('should put obects at the right place when the path is more than 1 element', function() {
+            ns('it.should.be.here', obj);
+            expect('it' in window).toBe(true);
+            expect(window.it.should.be.here).toBe(obj);
+        });
+
+        it('should still create the tree even if the object is undefined', function() {
+            ns('it2.should.be.here');
+            expect('it2' in window).toBe(true);
+            expect(window.it2.should.be).not.toBeUndefined();
+            expect('here' in window.it2.should.be).toBe(true);
+            expect(window.it2.should.be.here).toBeUndefined();
+        });
+
+        it('should still create the tree even if the object is null', function() {
+            ns('it3.should.be.here', null);
+            expect('it3' in window).toBe(true);
+            expect(window.it3.should.be).not.toBeUndefined();
+            expect('here' in window.it3.should.be).toBe(true);
+            expect(window.it3.should.be.here).toBe(null);
+        });
+
+        it('should return the object passed in', function() {
+            var result = ns('it3.should.be.here', obj);
+            expect(result).toBe(obj);
+        });
+    });
+});

--- a/test/namespaceSpec.js
+++ b/test/namespaceSpec.js
@@ -57,5 +57,15 @@ define(function(require) {
             var result = ns('it3.should.be.here', obj);
             expect(result).toBe(obj);
         });
+
+        it('should remove all non alpha-numerics besides $_', function() {
+            ns('!@#%^&*()_$+=-,./<>?:";\'[]{}\\|abc123', obj);
+            expect(window._$.abc123).toBe(obj);
+        });
+
+        it('should do nothing if the path is empty', function() {
+            var result = ns('', obj);
+            expect(result).toBeUndefined();
+        });
     });
 });


### PR DESCRIPTION
# Easily set namespaced objects

Added a function to set an object at a dot delimited path on window. This lets you easily build a namespaced tree of variables or objects.

# Examples
``` javascript
ns('path1.path2.ObjectName', obj);
// window.path1.path2 === obj

ns('MyObject', obj); // places it directly on window
//window.MyObject === obj
```
