### PR TITLE
HY-2651 Add Scroll Detection

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
             requireConfig: {
                 paths: {
                     modernizr: 'bower_components/modernizr/modernizr',
+                    lodash: 'bower_components/lodash/lodash',
                     bowser: 'bower_components/bowser/bowser',
                     'wf-js-common': './src',
                     'test': './test'

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "smithy.yaml"
   ],
   "dependencies": {
+    "lodash": "3.6.0",
     "modernizr": "2.6.2",
     "bowser": "0.7.2"
   },

--- a/src/MouseAdapter.js
+++ b/src/MouseAdapter.js
@@ -269,7 +269,7 @@ define(function(require) {
         }
         result = result % DELTA_ARRAY_SIZE;
         return result;
-    };
+    }
 
     //---------------------------------------------------------
     //
@@ -491,7 +491,7 @@ define(function(require) {
                     return -1; // Decreasing trend
                 }
                 return 0; // Stable
-            };
+            }
 
             /*
              * This is a helper function for detecting user scroll events.  The scroll deltas
@@ -520,7 +520,7 @@ define(function(require) {
                     }
                 }
                 return false;
-            };
+            }
 
             /*
              * This is a helper function for detecting user scroll events.  When the user
@@ -560,7 +560,7 @@ define(function(require) {
                     }
                 }
                 return false;
-            };
+            }
 
             // Store the newest data point in the history array, overwriting the oldest.
             deltaArrayY[deltaArrayIndex] = Math.abs(normalizedEvent.distance.y);

--- a/src/MouseAdapter.js
+++ b/src/MouseAdapter.js
@@ -247,7 +247,7 @@ define(function(require) {
      * For example: 
      *   getDeltaArrayIndex(0) will return the index of the oldest data point
      *   getDeltaArrayIndex(DELTA_ARRAY_SIZE-1) will return the most recent data index.
-     *   getDeltaArrayIndex(-1) will also return the most recent data point index.
+     *   getDeltaArrayIndex(-1) will return the most recent data point index.
      *   getDeltaArrayIndex(-DELTA_ARRAY_SIZE) will return the oldest data point index.
      * @type {Function}
      */
@@ -322,6 +322,10 @@ define(function(require) {
         this._debouncedDispatchMouseWheelEnd = FunctionUtil.debounce(
             this._dispatchMouseWheelEnd.bind(this), 100);
 
+        /**
+         * Throttled dispatcher for user initiated re-scroll events.
+         * @type {Function}
+         */
         this._throttledDispatchUserReScroll = _.throttle(
             this._dispatchUserReScroll.bind(this), 50);
 
@@ -388,8 +392,12 @@ define(function(require) {
             this._debouncedDispatchMouseWheelEnd(event);            
         },
 
+        /**
+         * Dispatches the MouseWheel start event, and handles related controls.
+         * @param {object} event
+         * @private
+         */
         _dispatchMouseWheelStart: function(event) {
-            //console.log('Start!');
             this.onMouseWheelStart.dispatch([{
                 distance: { x: 0, y: 0 },
                 source: event
@@ -397,11 +405,17 @@ define(function(require) {
             this._wheeling = true;
         },
 
+        /**
+         * Dispatches the MouseWheel end event, and handles related controls.
+         * @param {object} event
+         * @private
+         */
         _dispatchMouseWheelEnd: function(event) {
-            //console.log('End!');
+
+            // Reset the delta array on MouseEnd to prevent false positives between
+            // natural end and start events.
             deltaArray = [[],[]];
-            //console.log(this.str);
-            //this.str = '';
+
             this.onMouseWheelEnd.dispatch([{
                 distance: { x: 0, y: 0 },
                 source: event
@@ -409,6 +423,15 @@ define(function(require) {
             this._wheeling = false;
         },
 
+
+        /**
+         * Perform a ReScroll dispatch, which currently means dispatch a MouseEnd event 
+         * followed by a MouseStart event, to alert listeners that the user performed a
+         * new distinct scroll event.  This could easily be refactored into a separate
+         * observable if desired in the future.
+         * @param {object} event
+         * @private
+         */
         _dispatchUserReScroll: function(event) {
             this._dispatchMouseWheelEnd(event);
             this._dispatchMouseWheelStart(event);
@@ -473,7 +496,7 @@ define(function(require) {
                 detectDeltaIncrease(DELTA_INDEX.x) ||
                 detectDeltaIncrease(DELTA_INDEX.y);
 
-            if ( detected ) {
+            if (detected) {
                 this._throttledDispatchUserReScroll(event.source)
             }
         }

--- a/src/MouseAdapter.js
+++ b/src/MouseAdapter.js
@@ -213,64 +213,6 @@ define(function(require) {
      */
     var MAX_INERTIAL_DELAY = 90; // milliseconds
 
-    /**
-     * A constant which represents the maximum amount of data buffered.  That is, when 
-     * this value is N, the N most recent data points are preserved.  Beyond that, data 
-     * is overwritten.  This should only be large enough to hold the desired amount of 
-     * data and not any larger to preserve memory.
-     *
-     * This number is 10 because one detection method (_detectUserScroll.detectDeltaIncrease)
-     * uses the last 10 data points to determine whether a scroll was performed.
-     * @type {number}
-     */
-    var DELTA_ARRAY_SIZE = 10;
-    
-    /**
-     * A two dimensional array of size [2][DELTA_ARRAY_SIZE] which holds data captured.  
-     * It holds separate data for the X- and Y-axis, hence the 2.  Constants have been 
-     * created for accessing the array for clarity.
-     * @type {Array.<Array.<number>>}
-     */
-    var deltaArrayX = [];
-    var deltaArrayY = [];
-    
-    /**
-     * An index which always refers to the first (oldest) data point
-     * in the array.  It also represents the point that will be overwritten by new data.
-     * @type {number}
-     */
-    var deltaArrayIndex = 0;
-    
-    /**
-     * A helper function for calculating the index of the desired data given its 
-     * relative index.  Negative numbers can be used to access the N'th most recent
-     * data point.
-     *
-     * For example: 
-     *   getDeltaArrayIndex(0) will return the index of the oldest data point
-     *   getDeltaArrayIndex(DELTA_ARRAY_SIZE-1) will return the most recent data index.
-     *   getDeltaArrayIndex(-1) will return the most recent data point index.
-     *   getDeltaArrayIndex(-DELTA_ARRAY_SIZE) will return the oldest data point index.
-     * @type {Function}
-     * @return {number} The properly offset index of the requested data point.
-     */
-    function getDeltaArrayIndex(index) {
-        var result = (deltaArrayIndex+index);
-        if (index < 0) {
-            if (index < -DELTA_ARRAY_SIZE) {
-                throw new Error('Array index out of bounds!');
-            }
-            result += DELTA_ARRAY_SIZE;
-        }
-        else {
-            if (index >= DELTA_ARRAY_SIZE) {
-                throw new Error('Array index out of bounds!');
-            }
-        }
-        result = result % DELTA_ARRAY_SIZE;
-        return result;
-    }
-
     //---------------------------------------------------------
     //
     // MouseAdapter definition
@@ -331,6 +273,34 @@ define(function(require) {
          */
         this._throttledDispatchUserReScroll = _.throttle(
             this._dispatchUserReScroll.bind(this), 60);
+
+        /**
+         * A constant which represents the maximum amount of data buffered.  That is, when 
+         * this value is N, the N most recent data points are preserved.  Beyond that, data 
+         * is overwritten.  This should only be large enough to hold the desired amount of 
+         * data and not any larger to preserve memory.
+         *
+         * This number is 10 because one detection method (_detectDeltaIncrease)
+         * uses the last 10 data points to determine whether a scroll was performed.
+         * @type {number}
+         */
+        this.DELTA_ARRAY_SIZE = 10;
+        
+        /**
+         * A two dimensional array of size [2][DELTA_ARRAY_SIZE] which holds data captured.  
+         * It holds separate data for the X- and Y-axis, hence the 2.  Constants have been 
+         * created for accessing the array for clarity.
+         * @type {Array.<Array.<number>>}
+         */
+        this._deltaArrayX = [];
+        this._deltaArrayY = [];
+        
+        /**
+         * An index which always refers to the first (oldest) data point
+         * in the array.  It also represents the point that will be overwritten by new data.
+         * @type {number}
+         */
+        this._deltaArrayIndex = 0;
 
         //---------------------------------------------------------
         // Initialization
@@ -417,8 +387,8 @@ define(function(require) {
 
             // Reset the delta arrays on MouseEnd to prevent false positives between
             // natural end and start events.
-            deltaArrayX = [];
-            deltaArrayY = [];
+            this._deltaArrayX = [];
+            this._deltaArrayY = [];
 
             this.onMouseWheelEnd.dispatch([{
                 distance: { x: 0, y: 0 },
@@ -442,134 +412,167 @@ define(function(require) {
         },
 
         /**
+         * This is a helper function which takes in a set of consecutive linear data 
+         * and tries to determine whether it is increasing or decreasing.  It can
+         * operate on an entire array, or only a specified section of it. When given a
+         * starting point and a length that extends outside the boundaries of the array,
+         * the function assumes the data wraps around to the beginning of the array.
+         * @param {Array.<number>} array The array of data to perform analysis on.
+         * @param {number} arrayMaxLength [optional] The max length of the array.  If
+         * not given, assumed to be array.length
+         * @param {number} startAt [optional] The index in the array where the target 
+         * data begins.  If not specified, assumes this index is 0.
+         * @param {number} length [optional] The number of data points to examine.  
+         * If not specified, assumed to be the entire array length.
+         * @return {number} Returns:
+                1 if data appears to be increasing.
+               -1 if data appears to be decreasing.
+                0 if there is no discernable trend.
+         * @private
+         */
+        _calculateDeltaDirection: function(array, startAt, length, arrayMaxLength) {
+            arrayMaxLength = arrayMaxLength || array.length;
+            startAt = startAt || 0;
+            length = length || arrayMaxLength;
+            var total = 0;
+            var offsetIdx1,offsetIdx2;
+            for (var idx1 = 0; idx1 < length; idx1++) {
+                for (var idx2 = idx1+1; idx2 < length; idx2++) {
+                    offsetIdx1 = (idx1+startAt) % arrayMaxLength;
+                    offsetIdx2 = (idx2+startAt) % arrayMaxLength;
+                    if (array[offsetIdx1] < array[offsetIdx2]) {
+                        total += (1/(idx2-idx1));
+                    }
+                    if (array[offsetIdx1] > array[offsetIdx2]) {
+                        total += (-1/(idx2-idx1));
+                    }
+                }
+            }
+            if (total >= 1) {
+                return 1; // Increasing trend
+            }
+            if (total <= -1) {
+                return -1; // Decreasing trend
+            }
+            return 0; // Stable
+        },
+
+        /**
+         * This is a helper function for detecting user scroll events.  The scroll deltas
+         * will decay slowly over time, but they typically wont trend upwards again 
+         * unless the user performs another scroll.  Thus, when the scroll deltas are 
+         * trending downward and suddenly begin to increase, this is a strong indication 
+         * of a user event.  This function works by detecting these increases preceded by
+         * a normal decreasing trend.
+         *
+         * One advantage this method has is that it can detect nearly all user events.
+         * One disadvantage this method has is that it can be slow, owing to the fact 
+         * that it may take time (150ms+) to gather enough data before an upward trend is 
+         * discernable.
+         * @param {Array.<number>} array The array of data to analyze for this check
+         * @return {boolean} Returns true if conditions were satisfied to indicate the
+         * user performed a scroll event, else false
+         * @private
+         */
+        _detectDeltaIncrease: function(array) {
+            var firstRange = this._getDeltaArrayIndex(-5);
+            // Check the last 5 data points and determine if they are increasing
+            if (this._calculateDeltaDirection(array,firstRange,5,this.DELTA_ARRAY_SIZE) === 1) {
+                // Check the 5 data points prior to those and determine if they were decreasing
+                var secondRange = this._getDeltaArrayIndex(-10);
+                if (this._calculateDeltaDirection(array,secondRange,5,this.DELTA_ARRAY_SIZE) === -1) {
+                    return true;
+                }
+            }
+            return false;
+        },
+
+        /**
+         * This is a helper function for detecting user scroll events.  When the user
+         * performs a scroll (at least with a track pad), the scroll delta drops to 
+         * nearly 0 before the new momentum is added to the scroll inertia. Because the 
+         * inertia typically decays very slowly over time, a significant decrease in the 
+         * scroll delta is a strong indication of a user event. This function works by 
+         * detecting these negative spikes in the scroll delta.
+         *
+         * One advantage this method has is that it can detect events as soon as they 
+         * occur because it does not take time to collect data.
+         * One disadvantage this method has is that it cannot detect events when the 
+         * the current inertia is below a certain threshold, including really light 
+         * scrolls and scrolls made after the current scroll inertia has decayed a lot.
+         * @param {Array.<number>} array The array of data to analyze for this check
+         * @return {boolean} Returns true if conditions were satisfied to indicate the
+         * user performed a scroll event, else false
+         * @private
+         */
+        _detectNegativeSpike: function(array) {
+            var lastPoint = this._getDeltaArrayIndex(-1);
+            // Check if the current event delta is low.  Nearly all of the negative spikes 
+            // seem to reach between 0.5-2.5, so make sure the point is low enough
+            if (array[lastPoint] <= 5) {
+                var recentPoint2 = this._getDeltaArrayIndex(-2);
+                var recentPoint3 = this._getDeltaArrayIndex(-3);
+                // Check to see if the previous two points are significantly higher.
+                // Checks last TWO points instead of just last one because the deltas
+                // seem to be prone to intermittent noisy spikes which can create false
+                // positives.
+                var isFirstPointHigherMagnitude = array[recentPoint2] / array[lastPoint] > 2;
+                var isSecondPointHigherMagnitude = array[recentPoint3] / array[lastPoint] > 2;
+                var isFirstPointHigherValue = array[recentPoint2] - array[lastPoint] > 2;
+                var isSecondPointHigherValue = array[recentPoint3] - array[lastPoint] > 2;
+                if ((isFirstPointHigherMagnitude && isFirstPointHigherValue) &&
+                    (isSecondPointHigherMagnitude && isSecondPointHigherValue)) {
+                    return true;
+                }
+            }
+            return false;
+        },
+
+        /**
+         * A helper function for calculating the index of the desired data given its 
+         * relative index.  Negative numbers can be used to access the N'th most recent
+         * data point.
+         *
+         * For example: 
+         *   getDeltaArrayIndex(0) will return the index of the oldest data point
+         *   getDeltaArrayIndex(DELTA_ARRAY_SIZE-1) will return the most recent data index.
+         *   getDeltaArrayIndex(-1) will return the most recent data point index.
+         *   getDeltaArrayIndex(DELTA_ARRAY_SIZE) will return the oldest data point index.
+         * @type {Function}
+         * @return {number} The properly offset index of the requested data point.
+         */
+        _getDeltaArrayIndex: function(index) {
+            var result = (this._deltaArrayIndex+index);
+            if (index < 0) {
+                if (index < -this.DELTA_ARRAY_SIZE) {
+                    throw new Error('Array index out of bounds!');
+                }
+                result += this.DELTA_ARRAY_SIZE;
+            }
+            else {
+                if (index >= this.DELTA_ARRAY_SIZE) {
+                    throw new Error('Array index out of bounds!');
+                }
+            }
+            result = result % this.DELTA_ARRAY_SIZE;
+            return result;
+        },
+
+        /**
          * Detect when the user performs a new scroll gesture.
          * @param {object} normalizedEvent
          * @private
          */
         _detectUserScroll: function(normalizedEvent) {
 
-            /*
-             * This is a helper function which takes in a set of consecutive linear data 
-             * and tries to determine whether it is increasing or decreasing.  It can
-             * operate on an entire array, or only a specified section of it. When given a
-             * starting point and a length that extends outside the boundaries of the array,
-             * the function assumes the data wraps around to the beginning of the array.
-             * @param {Array.<number>} array The array of data to perform analysis on.
-             * @param {number} arrayMaxLength [optional] The max length of the array.  If
-             * not given, assumed to be array.length
-             * @param {number} startAt [optional] The index in the array where the target 
-             * data begins.  If not specified, assumes this index is 0.
-             * @param {number} length [optional] The number of data points to examine.  
-             * If not specified, assumed to be the entire array length.
-             * @return {number} Returns:
-                    1 if data appears to be increasing.
-                   -1 if data appears to be decreasing.
-                    0 if there is no discernable trend.
-             */
-            function calculateDeltaDirection(array, startAt,length, arrayMaxLength) {
-                arrayMaxLength = arrayMaxLength || array.length;
-                startAt = startAt || 0;
-                length = length || arrayMaxLength;
-                var total = 0;
-                var offsetIdx1,offsetIdx2;
-                for (var idx1 = 0; idx1 < length; idx1++) {
-                    for (var idx2 = idx1+1; idx2 < length; idx2++) {
-                        offsetIdx1 = (idx1+startAt) % arrayMaxLength;
-                        offsetIdx2 = (idx2+startAt) % arrayMaxLength;
-                        if (array[offsetIdx1] < array[offsetIdx2]) {
-                            total += (1/(idx2-idx1));
-                        }
-                        if (array[offsetIdx1] > array[offsetIdx2]) {
-                            total += (-1/(idx2-idx1));
-                        }
-                    }
-                }
-                if (total >= 1) {
-                    return 1; // Increasing trend
-                }
-                if (total <= -1) {
-                    return -1; // Decreasing trend
-                }
-                return 0; // Stable
-            }
-
-            /*
-             * This is a helper function for detecting user scroll events.  The scroll deltas
-             * will decay slowly over time, but they typically wont trend upwards again 
-             * unless the user performs another scroll.  Thus, when the scroll deltas are 
-             * trending downward and suddenly begin to increase, this is a strong indication 
-             * of a user event.  This function works by detecting these increases preceded by
-             * a normal decreasing trend.
-             *
-             * One advantage this method has is that it can detect nearly all user events.
-             * One disadvantage this method has is that it can be slow, owing to the fact 
-             * that it may take time (150ms+) to gather enough data before an upward trend is 
-             * discernable.
-             * @param {Array.<number>} array The array of data to analyze for this check
-             * @return {boolean} Returns true if conditions were satisfied to indicate the
-             * user performed a scroll event, else false
-             */
-            function detectDeltaIncrease(array) {
-                var firstRange = getDeltaArrayIndex(-5);
-                // Check the last 5 data points and determine if they are increasing
-                if (calculateDeltaDirection(array,firstRange,5,DELTA_ARRAY_SIZE) === 1) {
-                    // Check the 5 data points prior to those and determine if they were decreasing
-                    var secondRange = getDeltaArrayIndex(-10);
-                    if (calculateDeltaDirection(array,secondRange,5,DELTA_ARRAY_SIZE) === -1) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            /*
-             * This is a helper function for detecting user scroll events.  When the user
-             * performs a scroll (at least with a track pad), the scroll delta drops to 
-             * nearly 0 before the new momentum is added to the scroll inertia. Because the 
-             * inertia typically decays very slowly over time, a significant decrease in the 
-             * scroll delta is a strong indication of a user event. This function works by 
-             * detecting these negative spikes in the scroll delta.
-             *
-             * One advantage this method has is that it can detect events as soon as they 
-             * occur because it does not take time to collect data.
-             * One disadvantage this method has is that it cannot detect events when the 
-             * the current inertia is below a certain threshold, including really light 
-             * scrolls and scrolls made after the current scroll inertia has decayed a lot.
-             * @param {Array.<number>} array The array of data to analyze for this check
-             * @return {boolean} Returns true if conditions were satisfied to indicate the
-             * user performed a scroll event, else false
-             */
-            function detectNegativeSpike(array) {
-                var lastPoint = getDeltaArrayIndex(-1);
-                // Check if the current event delta is low.  Nearly all of the negative spikes 
-                // seem to reach between 0.5-2.5, so make sure the point is low enough
-                if (array[lastPoint] <= 5) {
-                    var recentPoint2 = getDeltaArrayIndex(-2);
-                    var recentPoint3 = getDeltaArrayIndex(-3);
-                    // Check to see if the previous two points are significantly higher.
-                    // Checks last TWO points instead of just last one because the deltas
-                    // seem to be prone to intermittent noisy spikes which can create false
-                    // positives.
-                    var isFirstPointHigherMagnitude = array[recentPoint2] / array[lastPoint] > 2;
-                    var isSecondPointHigherMagnitude = array[recentPoint3] / array[lastPoint] > 2;
-                    var isFirstPointHigherValue = array[recentPoint2] - array[lastPoint] > 2;
-                    var isSecondPointHigherValue = array[recentPoint3] - array[lastPoint] > 2;
-                    if ((isFirstPointHigherMagnitude && isFirstPointHigherValue) &&
-                        (isSecondPointHigherMagnitude && isSecondPointHigherValue)) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
             // Store the newest data point in the history array, overwriting the oldest.
-            deltaArrayY[deltaArrayIndex] = Math.abs(normalizedEvent.distance.y);
-            deltaArrayX[deltaArrayIndex] = Math.abs(normalizedEvent.distance.x);
-            deltaArrayIndex = (deltaArrayIndex+1) % DELTA_ARRAY_SIZE; // Increment index
+            this._deltaArrayY[this._deltaArrayIndex] = Math.abs(normalizedEvent.distance.y);
+            this._deltaArrayX[this._deltaArrayIndex] = Math.abs(normalizedEvent.distance.x);
+            this._deltaArrayIndex = (this._deltaArrayIndex+1) % this.DELTA_ARRAY_SIZE; // Increment index
 
             var detected =
-                detectNegativeSpike(deltaArrayY) || detectDeltaIncrease(deltaArrayY) ||
-                detectNegativeSpike(deltaArrayX) || detectDeltaIncrease(deltaArrayX);
+                this._detectNegativeSpike(this._deltaArrayY) || this._detectDeltaIncrease(this._deltaArrayY) ||
+                this._detectNegativeSpike(this._deltaArrayX) || this._detectDeltaIncrease(this._deltaArrayX);
 
             if (detected) {
                 this._throttledDispatchUserReScroll(normalizedEvent.source);

--- a/src/MouseAdapter.js
+++ b/src/MouseAdapter.js
@@ -324,14 +324,14 @@ define(function(require) {
          * @type {Function}
          */
         this._debouncedDispatchMouseWheelEnd = FunctionUtil.debounce(
-            this._dispatchMouseWheelEnd.bind(this), 80);
+            this._dispatchMouseWheelEnd.bind(this), 90);
 
         /**
          * Throttled dispatcher for user initiated re-scroll events.
          * @type {Function}
          */
         this._throttledDispatchUserReScroll = _.throttle(
-            this._dispatchUserReScroll.bind(this), 50);
+            this._dispatchUserReScroll.bind(this), 60);
 
         //---------------------------------------------------------
         // Initialization
@@ -462,8 +462,8 @@ define(function(require) {
              * @param {number} length [optional] The number of data points to examine.  
              * If not specified, assumed to be the entire array length.
              * @return {number} Returns:
-                    1 if data appears to be increasing
-                   -1 if data appears to be decreasing
+                    1 if data appears to be increasing.
+                   -1 if data appears to be decreasing.
                     0 if there is no discernable trend.
              */
             var calculateDeltaDirection = function(array,startAt,length,arrayMaxLength) {

--- a/src/MouseAdapter.js
+++ b/src/MouseAdapter.js
@@ -446,7 +446,7 @@ define(function(require) {
          * @param {object} normalizedEvent
          * @private
          */
-         _detectUserScroll: function(normalizedEvent) {
+        _detectUserScroll: function(normalizedEvent) {
 
             /**
              * This is a helper function which takes in a set of consecutive linear data 
@@ -519,7 +519,7 @@ define(function(require) {
                     }
                 }
                 return false;
-            };            
+            };
 
             /**
              * This is a helper function for detecting user scroll events.  When the user
@@ -559,9 +559,10 @@ define(function(require) {
                 return false;
             };
 
+            // Store the newest data point in the history array, overwriting the oldest.
             deltaArray[DELTA_INDEX.y][deltaArrayIndex] = Math.abs(normalizedEvent.distance.y);
             deltaArray[DELTA_INDEX.x][deltaArrayIndex] = Math.abs(normalizedEvent.distance.x);
-            deltaArrayIndex = (deltaArrayIndex+1) % DELTA_ARRAY_SIZE;
+            deltaArrayIndex = (deltaArrayIndex+1) % DELTA_ARRAY_SIZE; // Increment index
 
             var detected =
                 detectNegativeSpike(DELTA_INDEX.y) ||

--- a/src/MouseAdapter.js
+++ b/src/MouseAdapter.js
@@ -448,7 +448,7 @@ define(function(require) {
          */
         _detectUserScroll: function(normalizedEvent) {
 
-            /**
+            /*
              * This is a helper function which takes in a set of consecutive linear data 
              * and tries to determine whether it is increasing or decreasing.  It can
              * operate on an entire array, or only a specified section of it. When given a
@@ -493,7 +493,7 @@ define(function(require) {
                 return 0; // Stable
             };
 
-            /**
+            /*
              * This is a helper function for detecting user scroll events.  The scroll deltas
              * will decay slowly over time, but they typically wont trend upwards again 
              * unless the user performs another scroll.  Thus, when the scroll deltas are 
@@ -521,7 +521,7 @@ define(function(require) {
                 return false;
             };
 
-            /**
+            /*
              * This is a helper function for detecting user scroll events.  When the user
              * performs a scroll (at least with a track pad), the scroll delta drops to 
              * nearly 0 before the new momentum is added to the scroll inertia. Because the 

--- a/src/MouseAdapter.js
+++ b/src/MouseAdapter.js
@@ -571,7 +571,7 @@ define(function(require) {
                 detectDeltaIncrease(DELTA_INDEX.x);
 
             if (detected) {
-                this._throttledDispatchUserReScroll(event.source);
+                this._throttledDispatchUserReScroll(normalizedEvent.source);
             }
         }
     };

--- a/test/MouseAdapterSpec.js
+++ b/test/MouseAdapterSpec.js
@@ -252,7 +252,7 @@ define(function(require) {
             }]);
         });
 
-        it('should dispatch "onMouseWheelEnd" 80ms after the last mouse wheel', function() {
+        it('should dispatch "onMouseWheelEnd" 90ms after the last mouse wheel', function() {
             spyOn(adapter.onMouseWheelEnd, 'dispatch');
             var evt = {
                 currentTarget: target,
@@ -262,7 +262,7 @@ define(function(require) {
                 VERTICAL_AXIS: 'y'
             };
             adapter._onMouseWheel(evt);
-            waits(80);
+            waits(90);
             runs(function() {
                 expect(adapter.onMouseWheelEnd.dispatch).toHaveBeenCalledWith([{
                     distance: { x: 0, y: 0 },

--- a/test/MouseAdapterSpec.js
+++ b/test/MouseAdapterSpec.js
@@ -252,7 +252,7 @@ define(function(require) {
             }]);
         });
 
-        it('should dispatch "onMouseWheelEnd" 50ms after the last mouse wheel', function() {
+        it('should dispatch "onMouseWheelEnd" 80ms after the last mouse wheel', function() {
             spyOn(adapter.onMouseWheelEnd, 'dispatch');
             var evt = {
                 currentTarget: target,
@@ -262,7 +262,7 @@ define(function(require) {
                 VERTICAL_AXIS: 'y'
             };
             adapter._onMouseWheel(evt);
-            waits(50);
+            waits(80);
             runs(function() {
                 expect(adapter.onMouseWheelEnd.dispatch).toHaveBeenCalledWith([{
                     distance: { x: 0, y: 0 },

--- a/test/MouseAdapterSpec.js
+++ b/test/MouseAdapterSpec.js
@@ -270,5 +270,123 @@ define(function(require) {
                 }]);
             });
         });
+
+        describe('user scroll detection', function() {
+
+            describe('_calculateDeltaDirection', function() {
+                it('should detect an increasing trend in the data', function() {
+                    expect(adapter._calculateDeltaDirection([1, 2, 3, 4, 5])).toBe(1);
+                    expect(adapter._calculateDeltaDirection([1, 1, 1, 2, 2])).toBe(1);
+                    expect(adapter._calculateDeltaDirection([-10, -8, -9, -7, -8])).toBe(1);
+                });
+
+                it('should detect a decreasing trend in the data', function() {
+                    expect(adapter._calculateDeltaDirection([5, 4, 3, 2, 1])).toBe(-1);
+                    expect(adapter._calculateDeltaDirection([2, 2, 1, 1, 1])).toBe(-1);
+                    expect(adapter._calculateDeltaDirection([-8, -7, -9, -8, -10])).toBe(-1);
+                });
+
+                it('should detect a stable trend in the data', function() {
+                    expect(adapter._calculateDeltaDirection([99, 99, 99, 99, 99])).toBe(0);
+                    expect(adapter._calculateDeltaDirection([1, 2, 1, 2, 1])).toBe(0);
+                    expect(adapter._calculateDeltaDirection([10, 9, 5, 9, 10])).toBe(0);
+                });
+
+                it('should begin at the specified offset when passed in', function() {
+                    expect(adapter._calculateDeltaDirection([1, 1, 1, 1, 2, 2, 2, 2], 0)).toBe(1);
+                    expect(adapter._calculateDeltaDirection([1, 1, 1, 1, 2, 2, 2, 2], 4)).toBe(-1);
+                });
+
+                it('should stop at the specified length when passed in', function() {
+                    expect(adapter._calculateDeltaDirection([1, 1, 1, 1, 2, 2, 2, 2], 0, 4)).toBe(0);
+                    expect(adapter._calculateDeltaDirection([1, 1, 1, 1, 2, 2, 2, 2], 4, 4)).toBe(0);
+                });
+
+            });
+
+            describe('_detectNegativeSpike', function() {
+                // Test arrays in this block should be of size MouseAdapter.DELTA_ARRAY_SIZE,
+                // representing mouse event deltas received in chronological order from index 0.
+
+                it('should detect sufficiently steep negative spikes in data', function() {
+                    expect(adapter._detectNegativeSpike([63.5, 62, 59, 110, 49.5, 45, 41, 37.5, 34.5, 0.5])).toBe(true);
+                    expect(adapter._detectNegativeSpike([29, 26.5, 24, 21.5, 20, 18, 32, 14, 13, 0.5])).toBe(true);
+                    expect(adapter._detectNegativeSpike([6, 5.5, 5, 5, 4.5, 4, 3.5, 3, 3, 0.5])).toBe(true);
+                });
+
+                it('should not react to noisy spikes in data', function() {
+                    expect(adapter._detectNegativeSpike([30, 63.5, 65.5, 136, 66.5, 63.5, 62, 59, 110, 49.5])).toBe(false);
+                    expect(adapter._detectNegativeSpike([6, 5.5, 5, 5, 4.5, 4, 3.5, 3, 10, 2])).toBe(false);
+                });
+            });
+
+            describe('_detectDeltaIncrease', function() {
+                // Test arrays in this block should be of size MouseAdapter.DELTA_ARRAY_SIZE,
+                // representing mouse event deltas received in chronological order from index 0.
+
+                it('should detect increasing trends in data that are preceded by a decreasing trend', function() {
+                    expect(adapter._detectDeltaIncrease([9, 22, 6, 6, 5.5, 5, 4.5, 4, 6.5, 10.33333333])).toBe(true);
+                    expect(adapter._detectDeltaIncrease([2.5, 2.5, 2, 2, 2, 1.5, 0.5, 2.5, 3, 3.5])).toBe(true);
+                });
+
+                it('should not react to increasing trends in data that are NOT preceded by a decreasing trend', function() {
+                    expect(adapter._detectDeltaIncrease([8, 9, 16, 17.5, 19, 19, 25, 54, 56.5, 58.5])).toBe(false);
+                    expect(adapter._detectDeltaIncrease([19, 26, 26.5, 29.5, 32, 34, 26.5, 40.5, 19, 72.5])).toBe(false);
+                });
+            });
+
+            describe('_detectUserScroll', function() {
+
+                function testUserScrollDetection(array, shouldBeDetected) {
+                    adapter = new MouseAdapter(target);
+                    spyOn(adapter, '_throttledDispatchUserReScroll');
+
+                    for ( var idx = 0; idx < array.length; idx++ ) {
+                        adapter._detectUserScroll({
+                            distance: {
+                                x: 0,
+                                y: array[idx]
+                            },
+                            source: 'UnitTest'
+                        });
+                    }
+                    if (shouldBeDetected) {
+                        expect(adapter._throttledDispatchUserReScroll).toHaveBeenCalled();
+                    }
+                    else {
+                        expect(adapter._throttledDispatchUserReScroll).not.toHaveBeenCalled();
+                    }
+                    adapter.dispose();
+                }
+
+                it('should emit events when User-scroll is detected', function() {
+                    // This section includes all of the test data from the previous detection sections which
+                    // should be detected successfully.
+                    testUserScrollDetection([63.5, 62, 59, 110, 49.5, 45, 41, 37.5, 34.5, 0.5], true);
+                    testUserScrollDetection([29, 26.5, 24, 21.5, 20, 18, 32, 14, 13, 0.5], true);
+                    testUserScrollDetection([6, 5.5, 5, 5, 4.5, 4, 3.5, 3, 3, 0.5], true);
+                    testUserScrollDetection([9, 22, 6, 6, 5.5, 5, 4.5, 4, 6.5, 10.33333333], true);
+                    testUserScrollDetection([2.5, 2.5, 2, 2, 2, 1.5, 0.5, 2.5, 3, 3.5], true);
+
+                    // And a couple more
+                    testUserScrollDetection([10.33333333, 10, 9.5, 9.5, 9, 8, 20.5, 6, 5.5, 5, 4.5, 4, 3.5, 3.5, 0.5, 3.5, 5, 75.5, 34.5, 31.5], true);
+                    testUserScrollDetection([6, 5.5, 5, 4.5, 4, 3.5, 3.5, 3, 3, 2.5, 2.5, 2.5, 2, 0.5, 2, 3, 3.5, 7, 6.5, 13], true);
+                });
+
+                it('should not emit events when User-scroll is not detected', function() {
+                    // This section includes all of the test data from the previous detection sections which
+                    // should not trigger events
+                    testUserScrollDetection([30, 63.5, 65.5, 136, 66.5, 63.5, 62, 59, 110, 49.5], false);
+                    testUserScrollDetection([6, 5.5, 5, 5, 4.5, 4, 3.5, 3, 10, 2], false);
+                    testUserScrollDetection([8, 9, 16, 17.5, 19, 19, 25, 54, 56.5, 58.5], false);
+                    testUserScrollDetection([19, 26, 26.5, 29.5, 32, 34, 26.5, 40.5, 19, 72.5], false);
+
+                    // And a couple more
+                    testUserScrollDetection([25, 19.5, 25.5, 26.5, 26.5, 19, 18, 52.5, 51.5, 52, 51.5, 50, 48.5, 47, 45.5, 41.83333333, 38, 34.5, 31.5, 29], false);
+                    testUserScrollDetection([1.5, 2 ,3 ,4, 5, 6.5, 10.33333333, 12, 16.5, 20.5, 16.5, 22, 29, 93, 23.5, 18, 25.5, 51, 51.5, 51.5], false);
+                });
+
+            });
+        });
     });
 });


### PR DESCRIPTION
JIRA >> https://jira.atl.workiva.net/browse/HY-2651
@timmccall-wf @tomconnell-wf @todbachman-wf Code Review

## Problem Summary
The behavior surrounding scroll inertia is often obnoxious at best.  Right now, when beginning a scroll, a MouseWheelStart event is fired.  This is followed by some number of MouseWheel Events (which include synthetic momentum-driven events), independent of how many scrolls are actually performed, or even if the scroll switches directions.  It would be nice if there was a way to detect when a user physically initiates a new scroll gesture.

## Solution
Implemented a solution in the MouseAdapter based on statistical analysis, looking at the recent history of scroll deltas and looking for patterns that indicate that a user performed a new scroll event.

## Unit tests
One changed, none added yet.  I'm trying to decide on a practical way to unit test this functionality.  Right now, the only option i can think of is to feed in a long lists of fake MouseEvents/deltas that should indicate a user scroll and test whether it detected it or not.  But this doesn't seem very elegant.  Additionally, i don't like the idea of such implementation dependent test cases, where slight tweaks and  changes under the abstraction hood can cause little or no functional difference, but can cause tightly fitted unit tests to fail en masse.  If reviewer(s) have any opinions and/or suggestions, they would be appreciated.

## How to QA/+10
1. bower link this branch of wf-common into wf-uicomponents and run `grunt serve` in wf-uicomponents directory.  This should automatically pop up a window for functionally testing wf-uicomponents.
2. Open the debug console and put a breakpoint at `bower_components/wf-common/src/MouseAdapter.js:320` inside the MouseAdapter constructor, after the observables are set up.  Refresh.
3. While breakpointed, attach a debugging function to the onMouseWheelStart and/or onMouseWheelEnd observables to see when they are fired.  I use `this.onMouseWheelStart(function(event) { console.log("Start event!"); }); this.onMouseWheelEnd(function(event) { console.log("End event!"); });`
4. Thoroughly test the scroll behavior, use your best judgement to determine if events are firing reasonably and consistently with your scroll gestures.  Pay particular attention to scrolling gestures you make between a cold start and debounced end-event, as those are the events this PR is all about.