### PR TITLE
Add a PubSub implementation

### DIFF
--- a/src/PubSub.js
+++ b/src/PubSub.js
@@ -1,0 +1,54 @@
+define(function(require) {
+    'use strict';
+
+    function PubSub() {
+        this.subs = {};
+    }
+
+    PubSub.prototype = {
+
+        sub: function sub(name, callback) {
+            if (!this.subs[name]) {
+              this.subs[name] = [];
+            }
+
+            this.subs[name].push(callback);
+        },
+
+        unsub: function unsub(name, callback) {
+            if (!this.subs[name]) {
+              return;
+            }
+
+            var index = this.subs[name].indexOf(callback);
+
+            if (index === -1){
+              return;
+            }
+
+            this.subs[name].splice(index, 1);
+        },
+
+        pub: function pub(name, message) {
+            if (!this.subs[name]) {
+              return;
+            }
+            var thesubs = this.subs[name];
+            for (var i = 0; i < thesubs.length; i++) {
+                var subscriber = thesubs[i];
+                subscriber(message);
+            }
+        },
+
+        unsubAll: function unsubAll() {
+            this.subs = {};
+        }
+    };
+
+    var _instance;
+    if (!_instance) {
+        _instance = new PubSub();
+    }
+
+    return _instance;
+});

--- a/src/PubSub.js
+++ b/src/PubSub.js
@@ -26,7 +26,7 @@ define(function(require) {
 
     function joinName(name) {
         if (name && Array.isArray(name)) {
-            name = name.join('_');
+            name = name.join('');
         }
         return name;
     }

--- a/src/PubSub.js
+++ b/src/PubSub.js
@@ -1,5 +1,35 @@
+/*
+ * Copyright 2015 WebFilings, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 define(function(require) {
     'use strict';
+
+    // polyfill Array.isArray if needed
+    if (!Array.isArray) {
+      Array.isArray = function(arg) {
+        return Object.prototype.toString.call(arg) === '[object Array]';
+      };
+    }
+
+    function joinName(name) {
+        if (name && Array.isArray(name)) {
+            name = name.join('_');
+        }
+        return name;
+    }
 
     function PubSub() {
         this.subs = {};
@@ -8,6 +38,7 @@ define(function(require) {
     PubSub.prototype = {
 
         sub: function sub(name, callback) {
+            name = joinName(name);
             if (!this.subs[name]) {
               this.subs[name] = [];
             }
@@ -16,6 +47,7 @@ define(function(require) {
         },
 
         unsub: function unsub(name, callback) {
+            name = joinName(name);
             if (!this.subs[name]) {
               return;
             }
@@ -30,6 +62,7 @@ define(function(require) {
         },
 
         pub: function pub(name, message) {
+            name = joinName(name);
             if (!this.subs[name]) {
               return;
             }

--- a/test/PubSubSpec.js
+++ b/test/PubSubSpec.js
@@ -1,0 +1,46 @@
+define(function(require) {
+    'use strict';
+
+    var ps = require('wf-js-common/PubSub');
+
+    describe('PubSub', function() {
+
+        var key = 'callme';
+
+        beforeEach(function() {
+            ps.unsubAll();
+        });
+
+        it('should call the subscriber callback', function() {
+            var called = false;
+            ps.sub(key, function() {
+                called = true;
+            });
+            ps.pub(key);
+            expect(called).toBe(true);
+        });
+        it('should unsubscribe a subscriber', function() {
+            var fn = function() {
+                called = true;
+            };
+            var called = false;
+            ps.sub(key, fn);
+            ps.unsub(key, fn);
+            ps.pub(key)
+            expect(called).toBe(false);
+        });
+        it('should unsubscribe all subscribers', function() {
+            var fn = function() {
+                called = true;
+            };
+            var called = false;
+            ps.sub(key, fn);
+            ps.sub(key + key, fn);
+            ps.unsubAll();
+            ps.pub(key);
+            ps.pub(key + key);
+            expect(called).toBe(false);
+        });
+
+    });
+});

--- a/test/PubSubSpec.js
+++ b/test/PubSubSpec.js
@@ -21,7 +21,7 @@ define(function(require) {
 
     describe('PubSub', function() {
 
-        var key = 'call_me';
+        var key = 'callme';
 
         beforeEach(function() {
             ps.unsubAll();

--- a/test/PubSubSpec.js
+++ b/test/PubSubSpec.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 WebFilings, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 define(function(require) {
     'use strict';
 
@@ -5,19 +21,35 @@ define(function(require) {
 
     describe('PubSub', function() {
 
-        var key = 'callme';
+        var key = 'call_me';
 
         beforeEach(function() {
             ps.unsubAll();
         });
 
-        it('should call the subscriber callback', function() {
+        it('should call the subscriber callback with the passed message', function() {
             var called = false;
-            ps.sub(key, function() {
+            var msg = { my: 'data' };
+            var passed = null;
+            ps.sub(key, function(data) {
                 called = true;
+                passed = data;
             });
-            ps.pub(key);
+            ps.pub(key, msg);
             expect(called).toBe(true);
+            expect(passed).toBe(msg);
+        });
+        it('should call the subscriber with an array key joined by _', function() {
+            var called = false;
+            var msg = { my: 'data' };
+            var passed = null;
+            ps.sub(key, function(data) {
+                called = true;
+                passed = data;
+            });
+            ps.pub(['call','me'], msg);
+            expect(called).toBe(true);
+            expect(passed).toBe(msg);
         });
         it('should unsubscribe a subscriber', function() {
             var fn = function() {


### PR DESCRIPTION
# Overview
Provide a basic publish/subscribe implementation. This is useful as a central dispatch for events in an application.

