### PR TITLE
HY-2816 Removing from a Collection

### DIFF
--- a/src/observable/Collection.js
+++ b/src/observable/Collection.js
@@ -49,9 +49,12 @@ define([
             this.onChanged.dispatch([this, EVENTS.ITEM_ADDED, item]);
         },
         remove: function(item) {
+            if (item === null || item === undefined) {
+                return;
+            }
             var index = this._collection.indexOf(item);
-            this._remove(item);
             if (index >= 0) {
+                this._remove(item);
                 this._collection.splice(index, 1);
                 this.onChanged.dispatch([this, EVENTS.ITEM_REMOVED, item]);
             }

--- a/src/observable/Collection.js
+++ b/src/observable/Collection.js
@@ -49,9 +49,12 @@ define([
             this.onChanged.dispatch([this, EVENTS.ITEM_ADDED, item]);
         },
         remove: function(item) {
+            var index = this._collection.indexOf(item);
             this._remove(item);
-            this._collection.splice(this._collection.indexOf(item), 1);
-            this.onChanged.dispatch([this, EVENTS.ITEM_REMOVED, item]);
+            if (index >= 0) {
+                this._collection.splice(index, 1);
+                this.onChanged.dispatch([this, EVENTS.ITEM_REMOVED, item]);
+            }
         },
         reset: function(items) {
             for (var s = 0; s < this._collection.length; s++) {

--- a/test/observable/CollectionSpec.js
+++ b/test/observable/CollectionSpec.js
@@ -116,6 +116,13 @@ define([
                 collection.remove('never gonna give you up');
                 expect(collection.sizeOf()).toEqual(2);
                 expect(collection._collection).toEqual(['a value','c value']);
+
+                // trying to remove null shouldn't blow up or change the collection
+                expect(function() { collection.remove(null); }).not.toThrow();
+                expect(function() { collection.remove(undefined); }).not.toThrow();
+                expect(collection.sizeOf()).toEqual(2);
+                expect(collection._collection).toEqual(['a value','c value']);
+
             });
 
             it('should return index of given value', function() {

--- a/test/observable/CollectionSpec.js
+++ b/test/observable/CollectionSpec.js
@@ -112,6 +112,10 @@ define([
 
                 expect(collection.sizeOf()).toEqual(2);
                 expect(collection._collection).toEqual(['a value','c value']);
+
+                collection.remove('never gonna give you up');
+                expect(collection.sizeOf()).toEqual(2);
+                expect(collection._collection).toEqual(['a value','c value']);
             });
 
             it('should return index of given value', function() {


### PR DESCRIPTION
# Problem
Removing something not in a Collection, removes the last item instead. 

# Solution
Check to see if what you are trying to remove is actually in the collection before splicing the array.

# Test Overview
Covered by a unit test
